### PR TITLE
Make App ID Inputbox bigger

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
 {"description":"Stats of flathub.org","@type":"WebSite","headline":"Flathub Stats","url":"https://klausenbusk.github.io/flathub-stats/","name":"Flathub Stats","@context":"https://schema.org"}</script>
 	</head>
 	<body>
-		<input autocomplete="off" list="refs" id="ref">
+		<input autocomplete="off" list="refs" id="ref" style="width: 250px">
 		<datalist id="refs"></datalist>
 		<select autocomplete="off" id="interval-select">
 			<option value="infinity">∞</option>


### PR DESCRIPTION
Larger App IDs get currently cut off. For example, if you search the name of one of mine App's, which start all with com.gitlab.JakobDev.jd, you only see com.gitlab.JakobDev.jd but not the Rest of the Name, which is really annoying. 250px should be width enough for all App IDs.