### PR TITLE
Prevent chart being too tall and going offscreen

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -35,7 +35,11 @@
 		</select>
 		<p style="display:inline" id="basic-stats"></p>
 
-		<canvas id="chart"></canvas>
+		<!-- max-width is ~2:1 (chart aspect ratio) to height, so canvas doesn't get too tall -->
+		<div style="max-width: 190vh; margin: 0 auto;">
+			<canvas id="chart"></canvas>
+		</div>
+
 		<a href="https://github.com/klausenbusk/flathub-stats" target="_blank" rel="noreferrer">https://github.com/klausenbusk/flathub-stats</a>
 		<br>
 		<small>* An update is sometimes <a href="https://github.com/flathub/flathub/issues/177#issuecomment-650361779" target="_blank" rel="noreferrer">reported as an install</a></small>


### PR DESCRIPTION
The chart is currently too tall on some screens (like mine) so I've set a max size* on its parent as suggested by the [Chart.js documentation](https://www.chartjs.org/docs/latest/configuration/responsive.html).
(*The actual property I've changed is max-width because the height is automatically scaled based on the parent's width)

<img src="https://user-images.githubusercontent.com/21128619/191022555-90e7efe6-ea09-406a-97c2-07a23f2f944c.png" width=600>
