### PR TITLE
fix: set viewport meta tag for mobile

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
 		<title>Flathub Stats</title>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js" integrity="sha512-QoJS4DOhdmG8kbbHkxmB/rtPdN62cGWXAdAFWWJPvUFF1/zxcPSdAnn4HhYZSIlVoLVEJ0LesfNlusgm2bPfnA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Before and after:

<img src="https://github.com/klausenbusk/flathub-stats/assets/21128619/7fac7c31-e1ea-4b41-860e-bc12667bd7a5" width=300>
<img src="https://github.com/klausenbusk/flathub-stats/assets/21128619/858ec742-87cf-42f1-8adc-1a8805335002" width=300>